### PR TITLE
Fix build error: include proper sources in tests executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(googletest ${GOOGLETEST_SOURCES})
 add_executable (Schroedinger ${SOURCES})
 add_executable(
     unit_tests
+    src/potentials.cpp
     tests/main.cpp
 )
 add_dependencies(unit_tests googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable (Schroedinger ${SOURCES})
 add_executable(
     unit_tests
     src/potentials.cpp
+    src/Schroedinger.cpp
     tests/main.cpp
 )
 add_dependencies(unit_tests googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,9 @@ add_library(googletest ${GOOGLETEST_SOURCES})
 add_executable (Schroedinger ${SOURCES})
 add_executable(
     unit_tests
-    ${SOURCES}
+    src/potentials.cpp
+    src/Schroedinger.cpp
+    src/test.cpp
     tests/main.cpp
 )
 add_dependencies(unit_tests googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,7 @@ add_library(googletest ${GOOGLETEST_SOURCES})
 add_executable (Schroedinger ${SOURCES})
 add_executable(
     unit_tests
-    src/potentials.cpp
-    src/Schroedinger.cpp
+    ${SOURCES}
     tests/main.cpp
 )
 add_dependencies(unit_tests googletest)


### PR DESCRIPTION
There's a more elegant way to include source files in the tests executable, but that's a quick fix