### PR TITLE
Refactor Potential, create exception handling and add tests.

### DIFF
--- a/include/Potential.h
+++ b/include/Potential.h
@@ -5,83 +5,92 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <stdexcept>
 
 /*! Class Potential contains the potential used in the Schroedinger equation.
  * takes the necessary input: std::vector x at definition Builder(x),
  * it is as vector of position (or base states) to initialize the corresponding calculation.
  * The initialization uses the Builder design pattern. So after creating Potential::Builder object, you can set the
  * attributes and building using Potential V = object.setType("...").setK(0.).build()
+ *
  * Other inputs:
- * - string::pot_name, setType(string), sets the potential type that define a certain shape of the potential
+ * - string::type, setType(string), sets the potential type that define a certain shape of the potential
  *   ("box", "finite well", "harmonic oscillator")
  * - double k, setK(double), sets the harmonic oscillator strength parameter
  * - double width, setWidth(double), sets the finite well width.
  * - double height, setHeight(double), set the finite well depth.
+ *
  * Outputs:
  * - v, the std::vector of output, the value of the potential for every value of x.
+ *
+ * Eventually it throws invalid_argument exception if given parameters are wrong.
  */
 
 class Potential {
 private:
     std::vector<double> x;
     std::vector<double> v;
+    std::string type;
     double k;
     double width;
     double height;
-    std::string pot_name;
 
-    void ho_potential(double);
+    void ho_potential();
     void box_potential();
-    void finite_well_potential(double, double);
-
-public: class Builder{
-
-    private:
-        std::vector<double> x;
-        double k = 0.5;
-        double width = 5.;
-        double height = 10.;
-        std::string pot_name = "box";
-
-    public:
-        Builder(std::vector<double> x_new) {
-            this->x = x_new;
-        }
-
-        Builder setK(double k_new){
-            this->k = k_new;
-            return *this;
-        }
-
-        Builder setWidth(double width_new){
-            this->width = width_new;
-            return *this;
-        }
-
-        Builder setHeight(double height_new){
-            this->height = height_new;
-            return *this;
-        }
-
-        Builder setType(std::string name){
-            this->pot_name = name;
-            return *this;
-        }
-
-        Potential build(){
-            return Potential(this->x,this->pot_name,this->k,this->width,this->height);
-        }
-
-    };
-
-    Potential(std::vector<double>, std::string, double, double, double);
-
-//    Potential(std::vector<double>);
-//    Potential(std::vector<double>, std::string);
-//    Potential(std::vector<double>, std::string, double);
+    void finite_well_potential();
 
 public:
+    Potential(std::vector<double>, std::string, double, double, double);
     std::vector<double> get_v();
+
+    class Builder{
+        private:
+            std::vector<double> x;
+            std::string type     = "box";
+            double k             = 0.5;
+            double width         = 5.0;
+            double height        = 10.0;
+
+        public:
+            Builder(std::vector<double> x_new) {
+                this->x = x_new;
+            }
+
+            Builder setK(double k_new){
+                this->k = k_new;
+                return *this;
+            }
+
+            Builder setWidth(double width_new){
+                if (width_new >= 0) {
+                    this->width = width_new;
+                    return *this;
+                }
+                else throw std::invalid_argument("Width parameter cannot be negative.");
+            }
+
+            Builder setHeight(double height_new){
+                this->height = height_new;
+                return *this;
+            }
+
+            Builder setType(std::string type){
+                if (!type.empty()) {
+                    this->type = type;
+                    return *this;
+                }
+                else throw std::invalid_argument("Empty type given as parameter.");
+            }
+
+            Potential build(){
+                try {
+                    return Potential(this->x,this->type,this->k,this->width,this->height);
+                }
+                catch(const std::invalid_argument& e){
+                    throw;
+                }
+            }
+    };
 };
 
 

--- a/src/Potential.cpp
+++ b/src/Potential.cpp
@@ -1,46 +1,47 @@
 #include "../include/Potential.h"
 
-std::vector<double> Potential::get_v() {
-    return this->v;
-}
+Potential::Potential(std::vector<double> coord, std::string type, double k, double width, double height)
+{
+    this->x        = coord;
+    this->v        = std::vector<double>(x.size());
+    this->k        = k;
+    this->width    = width;
+    this->height   = height;
+    this->type     = type;
 
-Potential::Potential(std::vector<double> coord, std::string name, double k, double width, double height){
-//    std::cout << this->pot_name << " ?" << this->x.size() << std::endl;
-    this->x = coord;
-    this->v = x;
-    this->k = k;
-    this->width = width;
-    this->height = height;
-    this->pot_name = name;
-
-    if(name.compare("box potential") == 0 || name.compare("box") == 0 || name.compare("0") == 0)
+    if(type.compare("box potential") == 0 || type.compare("box") == 0 || type.compare("0") == 0)
         this->box_potential();
-    else if(name.compare("harmonic oscillator") == 0 || name.compare("ho") == 0 ||  name.compare("1") == 0)
-        this->ho_potential(k);
-    else if(name.compare("finite well potential") || name.compare("well") || name.compare("2") ){
-      this->finite_well_potential(this->height, this->width);
-    }
-    else{
-        std::cerr << "! ERROR: wrong potential name!\n! Potential" << name << "not known!\n"
-                  << "! or initialization meaningless" << std::endl;
-        exit(8);
+
+    else if(type.compare("harmonic oscillator") == 0 || type.compare("ho") == 0 ||  type.compare("1") == 0)
+        this->ho_potential();
+
+    else if(type.compare("finite well potential") == 0 || type.compare("well") == 0 || type.compare("2") == 0 )
+        this->finite_well_potential();
+
+    else {
+        throw std::invalid_argument("Wrong potential type ("+type+") or initialization meaningless!");
     }
 }
 
-void Potential::ho_potential(double k)
+void Potential::ho_potential()
 {
     for(std::vector<int>::size_type i = 0; i < x.size(); i++)
-        this->v[i] = this->x[i] * this->x[i] * k;
+        this->v[i] = this->x[i] * this->x[i] * this->k;
 }
 
 void Potential::box_potential()
 {
-    std::fill(this->v.begin(), this->v.end(), 0.);
+    std::fill(this->v.begin(), this->v.end(), 0.0);
 }
 
-void Potential::finite_well_potential(double height, double width)
+void Potential::finite_well_potential()
 {
-    for(std::vector<int>::size_type i = 0; i < x.size(); i++) {
-        this->v[i] = (this->x[i] > -width/2. && this->x[i] < width/2.) ? 0.0 : height;
-    }
+    for(std::vector<int>::size_type i = 0; i < x.size(); i++)
+        this->v[i] = (this->x[i] > -this->width/2.0 && this->x[i] < this->width/2.0) ? 0.0 : this->height;
 }
+
+std::vector<double> Potential::get_v()
+{
+    return this->v;
+}
+

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -21,24 +21,27 @@ void testWf(unsigned int nbox, std::string potType, double k, double width, doub
 
     *pot = V.get_v();
 
-    numerov_Wf[0] = 0.;
+    numerov_Wf[0] = 0.0;
     numerov_Wf[1] = 0.2; //later on it gets renormalized, so is just a conventional number
 
     double E_numerov = solve_Numerov(0., 2., 0.01, nbox, V, numerov_Wf);
     double E_analytic;
 
-    if(potType == "box"){
+    if(potType == "box") {
         E_analytic = box_wf(1, nbox, analytic_Wf);
-    }else if(potType == "harmonic oscillator"){
+    }
+    else if(potType == "harmonic oscillator") {
         E_analytic = harmonic_wf(0,nbox, sqrt(2.*k), analytic_Wf);
-    }else if(potType == "well") {
+    }
+    else if(potType == "well") {
         E_analytic = finite_well_wf(1, nbox, width, height, analytic_Wf);
-    }else{
+    }
+    else {
         std::cerr << "ERROR! Wrong potential name in set" << std::endl;
         exit(8);
     }
 
-    for(int i=0; i < nbox; i++){
+    for(int i=0; i < nbox; i++) {
         EXPECT_NEAR(numerov_Wf[i], analytic_Wf[i], 1e-2 ); //improve error definition
      }
 
@@ -46,10 +49,36 @@ void testWf(unsigned int nbox, std::string potType, double k, double width, doub
 }
 
 namespace {
-//
     TEST(NumTest,Hermite){
         ASSERT_NEAR(std::hermite(3, 10.), H3(10.),err);
         ASSERT_NEAR(std::hermite(4, 4.3), H4(4.3),err);
+    }
+
+    TEST(Potential, widthMustBePositive) {
+        std::vector<double> x;
+        try {
+            Potential p = Potential::Builder(x).setWidth(-1).build();
+            FAIL();
+        }
+        catch(std::invalid_argument e) {}
+    }
+
+    TEST(Potential, typeCannotBeEmpty) {
+        std::vector<double> x;
+        try {
+            Potential p = Potential::Builder(x).setType("").build();
+            FAIL();
+        }
+        catch(std::invalid_argument e) {}
+    }
+
+    TEST(Potential, typeMustBeKnown) {
+        std::vector<double> x;
+        try {
+            Potential p = Potential::Builder(x).setType("unknownType").build();
+            FAIL();
+        }
+        catch(std::invalid_argument e) {}
     }
 
     TEST(WfTest,HarmonicOscillator){
@@ -83,7 +112,7 @@ namespace {
         for(std::vector<int>::size_type i = 0; i < x.size(); i++)
             x[i] = dx * (int) (i - nbox / 2);
 
-        testWf(nbox, s,  1., 0., 0., x, &pot, numerov_Wf, analytic_Wf);
+        testWf(nbox, s,  1.0, 0.0, 0.0, x, &pot, numerov_Wf, analytic_Wf);
 
         if(HasFailure()){
             for(int i=0; i < nbox; i++)
@@ -104,7 +133,7 @@ namespace {
         for(std::vector<int>::size_type i = 0; i < x.size(); i++)
             x[i] = dx * (int) (i - nbox / 2);
 
-        testWf(nbox, s,  0., 0., 0., x, &pot, numerov_Wf, analytic_Wf);
+        testWf(nbox, s,  0.0, 0.0, 0.0, x, &pot, numerov_Wf, analytic_Wf);
 
         if(HasFailure()){
             for(int i=0; i < nbox; i++)
@@ -124,7 +153,7 @@ namespace {
         for(std::vector<int>::size_type i = 0; i < x.size(); i++)
             x[i] = dx * (int) (i - nbox / 2);
 
-        testWf(nbox, s,  0., 0., 0., x, &pot, numerov_Wf, analytic_Wf);
+        testWf(nbox, s,  0.0, 0.0, 0.0, x, &pot, numerov_Wf, analytic_Wf);
 
         if(HasFailure()){
             for(int i=0; i < nbox; i++)
@@ -133,7 +162,6 @@ namespace {
         }
     }
 
-//
     TEST(WfTest,FiniteWell1){
         unsigned int nbox = 2000;
         std::string s = "well";
@@ -159,7 +187,7 @@ namespace {
         unsigned int nbox = 1000;
         std::string s = "well";
 
-        double width = 7., height = 5.;
+        double width = 7.0, height = 5.0;
         double *numerov_Wf = new double[nbox];
         double *analytic_Wf = new double[nbox];
         std::vector<double> x(nbox), pot(nbox);
@@ -167,7 +195,7 @@ namespace {
         for(std::vector<int>::size_type i = 0; i < x.size(); i++)
             x[i] = dx * (int) (i - nbox / 2);
 
-        testWf(nbox, s,  0., width, height, x, &pot, numerov_Wf, analytic_Wf);
+        testWf(nbox, s,  0.0, width, height, x, &pot, numerov_Wf, analytic_Wf);
 
         if(HasFailure()){
             for(int i=0; i < nbox; i++)


### PR DESCRIPTION
Instead of using std::cerr when creating new Potential object, it's better to use std::illegal_argument exception. Now it's implemented, and I've also created 2 test with the exception handling for unknown type and empty type given as a parameter. In the Potential::Builder i've added exception for negative width, creating another test.