### PR TITLE
Redefine constants as constexprs, add proper check for cmath functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-## Schroedinger Solver     
-[![CircleCI](https://circleci.com/gh/Scienza/Schroedinger/tree/master.svg?style=shield)](https://circleci.com/gh/Scienza/Schroedinger/tree/dev) 
+# Schroedinger Solver
+
+[![CircleCI](https://circleci.com/gh/Scienza/Schroedinger/tree/master.svg?style=shield)](https://circleci.com/gh/Scienza/Schroedinger/tree/dev)
 ![Linux](https://img.shields.io/badge/linux-supported-brightgreen.svg)
 ![License](https://img.shields.io/badge/license-LGPL%20v2.1-blue.svg)
 
@@ -9,28 +10,30 @@ The potential is embedded in the code as a class, together with the basis. At th
 
 Output are the energy and the resulting wavefunction.
 
-### Numerov Solver
+## Numerov Solver
+
 Numerov solver takes in input an energy bracket in which to look for solution. Increasing from the minimum energy, it takes the lowest energy non-trivial solution as the one that respects boundary conditions.
 
-### Requisites
-- compiler which fully supports C++17, due to src implementation of Hermite polynomials in std available in the latest implementations of C++17. That is:
-  - g++ version newer than 6.0, due to src implementation of Hermite polynomials in std available in C++17.
-  - clang version > 9.0 (there are reports of it working for 5.0)
-  - Intel Compilers version > 18.0
-- Git
-- CMake
+## Requisites
 
-### How to build
+- A C++17-compliant compiler with special math functions support (gcc >= 6.1, clang >= 5.0.0, icc >= 18.0.0, MSVC >= 19.14)
+- CMake (>= 3.5)
+
+## How to build
+
 From the CLI navigate into project's directory, then run:
-```
+
+```bash
 $ mkdir build
 $ cd build
 $ cmake ..
 $ make
 ```
+
 You'll find the executable file in `Schroedinger/build/bin/`.
 
-### Contribute
-To contribute, considers the [issues](https://github.com/AndreaIdini/Schroedinger/issues) and the [to-do](https://github.com/AndreaIdini/Schroedinger/projects) lists. Good first issues are tagged appropriately, depending on contribution aspirations there are issues with different requirements of physics and computer science. 
+## Contribute
+
+To contribute, considers the [issues](https://github.com/AndreaIdini/Schroedinger/issues) and the [to-do](https://github.com/AndreaIdini/Schroedinger/projects) lists. Good first issues are tagged appropriately, depending on contribution aspirations there are issues with different requirements of physics and computer science.
 Watch the introduction video [video \(IT\)](https://www.youtube.com/watch?v=KH8xd0TKkz4) and contact [Andrea Idini](mailto:andrea.idini@gmail.com).
 Priviledged channel for contributions is the telegram group [@scienza](https://t.me/Scienza).

--- a/src/Solver/Numerov.cpp
+++ b/src/Solver/Numerov.cpp
@@ -68,7 +68,7 @@ State Numerov::solve(double e_min, double e_max, double e_step) {
         this->functionSolve(energy);
         double &last_wavefunction_value = this->wavefunction.at(this->nbox);
 
-        if ( fabs(last_wavefunction_value - this->wfAtBoundary) < err ) {
+        if ( fabs(last_wavefunction_value - this->wfAtBoundary) < err_thres ) {
             std::cout << "Solution found" << last_wavefunction_value << std::endl;
             this->solutionEnergy = energy;
             break;
@@ -120,7 +120,7 @@ double Numerov::bisection(double e_min, double e_max) {
     std::cout.precision(17);
 
     // The number of iterations that the bisection routine needs can be evaluated in advance
-    int itmax = ceil(log2(e_max - e_min) - log2(err)) - 1;
+    int itmax = ceil(log2(e_max - e_min) - log2(err_thres)) - 1;
 
     for (int i = 0; i < itmax; i++) {
         energy_middle = (e_max + e_min) / 2.0;
@@ -131,7 +131,7 @@ double Numerov::bisection(double e_min, double e_max) {
         this->functionSolve(e_max);
         fb = this->wavefunction.at(this->nbox) - this->wfAtBoundary;
 
-        if (std::abs(fx1) < err) {
+        if (std::abs(fx1) < err_thres) {
             return energy_middle;
         }
 
@@ -146,6 +146,6 @@ double Numerov::bisection(double e_min, double e_max) {
         }
     }
 
-    std::cerr << "WARNING: Solution not found at the set precision using the bisection method, " << this->wavefunction.at(this->nbox) << " > " << err << std::endl;
+    std::cerr << "WARNING: Solution not found at the set precision using the bisection method, " << this->wavefunction.at(this->nbox) << " > " << err_thres << std::endl;
     return energy_middle;
 }

--- a/src/Solver/Numerov.h
+++ b/src/Solver/Numerov.h
@@ -3,18 +3,21 @@
 
 #define __STDCPP_WANT_MATH_SPEC_FUNCS__ 1
 
-#define dx 0.01
-#define err 1E-10
-
-#define pi 3.14159265359
-#define hbar 1
-#define mass 1
-
 #include <cmath>
 #include <iostream>
 #include <vector>
 #include <string>
 #include <fstream> 
+
+#ifndef _MSC_VER
+        #if __STDCPP_MATH_SPEC_FUNCS__ < 201003L
+                #error "Special mathematical functions are not available \
+        in this cmath implementation. Cannot continue."
+        #endif
+#elif _MSC_VER < 1914
+        #error "Special mathematical functions are not available \
+in this MSVC version (need at least 19.14). Cannot continue."
+#endif
 
 #include "Solver.h"
 #include "Potential.h"
@@ -24,7 +27,7 @@ class Numerov : public Solver {
         public:
                 Numerov(Potential potential, int nbox);
                 State solve(double, double, double);
-
+                
                 /*! Integrate with the trapezoidal rule method, from a to b position in a function array*/
                 static double trapezoidalRule(int a, int b, double stepx, std::vector<double> function) {
                         double sum = 0.0;
@@ -34,7 +37,7 @@ class Numerov : public Solver {
                         sum = (sum) * stepx;
                         return sum;
                 }
-                
+
         private:
                 void functionSolve(double energy);
                 double bisection(double, double);

--- a/src/Solver/Solver.h
+++ b/src/Solver/Solver.h
@@ -1,16 +1,6 @@
 #ifndef SOLVER_H
 #define SOLVER_H
 
-#define __STDCPP_WANT_MATH_SPEC_FUNCS__ 1
-
-#define dx 0.01
-#define err 1E-10
-
-#define pi 3.14159265359
-#define hbar 1
-#define mass 1
-
-#include <cmath>
 #include <iostream>
 #include <vector>
 #include <string>
@@ -18,6 +8,14 @@
 
 #include "Potential.h"
 #include "State.h"
+
+constexpr double pi = 3.14159265358979323846;
+constexpr double pi_2 = 1.57079632679489661923;
+constexpr double hbar = 1;
+constexpr double mass = 1;
+constexpr double dx = 0.01;
+
+constexpr double err_thres = 10E-10;
 
 class Solver {
         public:

--- a/tests/analytical.cpp
+++ b/tests/analytical.cpp
@@ -43,17 +43,17 @@ double finite_well_wf(int nlevel, int nbox, double pot_width, double pot_height,
     double tolerance = 1e-10;
     int counter = 0;
 
-    eta_old = 1. + pi / 2. * (nlevel - 1);
+    eta_old = 1. + pi_2 * (nlevel - 1);
     // std::cout << "#" << eta_old << std::endl;
     do {
         counter++;
         eta = eta_old;
 
         if (nlevel % 2 == 0) { //looking for solution has n even, thus is odd parity
-            eta_old = atan(sqrt(xi*xi / eta / eta - 1) + pi / 2.) + pi / 2. * (nlevel - 1);
+            eta_old = atan(sqrt(xi*xi / eta / eta - 1) + pi_2) + pi_2 * (nlevel - 1);
         }
         else {             //looking for has n odd, thus is even parity
-            eta_old = atan(sqrt(xi*xi / eta / eta - 1)) - pi / 2. * (nlevel - 1);
+            eta_old = atan(sqrt(xi*xi / eta / eta - 1)) - pi_2 * (nlevel - 1);
         }
         //    std::cout << "#" << eta << " - " << eta_old << std::endl;
     } while (fabs((eta_old - eta) / eta) > tolerance && counter < 100);


### PR DESCRIPTION
The redefinition of constants was especially needed because, as macros, they clashed with other external libraries (logger PR incoming).

I chose to do an in-source check over CMake compiler-version-checking-hell because that alone is not enough (`std::hermite` is guaranteed to be available iff `__STDCPP_MATH_SPEC_FUNCS__ >= 201003L`; for whatever reason MSVC doesn't actually export that macro but it's known that the minimum version has to be 19.14 for these functions to be there)